### PR TITLE
Workaround to avoid problematic uninstall code path.

### DIFF
--- a/src/rosdep2/platforms/windows.py
+++ b/src/rosdep2/platforms/windows.py
@@ -107,6 +107,12 @@ class ChocolateyInstaller(PackageManagerInstaller):
 
         # interactive switch doesn't matter
         if reinstall:
+            # previous we explicitly uninstall and install packages, however
+            # we noticed there are some problematic code path inside packages'
+            # uninstall scripts.
+            # so here we workaround that by only doing force upgrade, and we
+            # should revisit this after we figure out the root cause of the
+            # uninstall scripts.
             return [['choco', 'upgrade', '-f', '-y', p] for p in packages]
         else:
             return [['choco', 'upgrade', '-y', p] for p in packages]

--- a/src/rosdep2/platforms/windows.py
+++ b/src/rosdep2/platforms/windows.py
@@ -107,11 +107,6 @@ class ChocolateyInstaller(PackageManagerInstaller):
 
         # interactive switch doesn't matter
         if reinstall:
-            commands = []
-            for p in packages:
-                # --force uninstalls all versions of that package
-                commands.append(['choco', 'uninstall', '--force', '-y', p])
-                commands.append(['choco', 'install', '-y', p])
-            return commands
+            return [['choco', 'upgrade', '-f', '-y', p] for p in packages]
         else:
             return [['choco', 'upgrade', '-y', p] for p in packages]


### PR DESCRIPTION
Use `choco upgrade` to workaround packages with problematic uninstall tasks (for packages using `Uninstall-ChocolateyZipPackage` in `ChocolateyUninstall.ps1` exhibiting a behavior to delete the common folder like `c:\opt\rosdeps\x64\bin`).

This pull request is trying to stop the problematic uninstall path to be propagated to any newly installations.

NOTE: Here is a table when the Chocolatey scripts get triggered: https://chocolatey.org/docs/create-packages#during-which-scenarios-will-my-custom-scripts-be-triggered